### PR TITLE
Use mini_magick instead of rmagick

### DIFF
--- a/aaq.gemspec
+++ b/aaq.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "aaq/version"
-
 Gem::Specification.new do |spec|
   spec.name          = "aaq"
   spec.version       = AAQ::VERSION
@@ -27,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.58"
 
-  spec.add_dependency "rmagick", "~> 2.16"
+  spec.add_dependency "mini_magick", "~> 4.9.2"
 end


### PR DESCRIPTION
`rmagick` が古い `ImageMagick` を要求してきたため、`mini_magick` に置き換えてみました。

以下の点、相談できればと思います。
1. ピクセルの色の浮動少数の扱いなどが少し変わっています。
1. 透明度のコードがちょっとわからない部分があり、TODOにしてあります。